### PR TITLE
Added map[string]string suport for extra data in sections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/peterebden/gcfg
 
+go 1.16
+
 require gopkg.in/warnings.v0 v0.1.2

--- a/read_test.go
+++ b/read_test.go
@@ -82,6 +82,19 @@ type cBoolS1 struct{ Bool bool }
 type cTxUnm struct{ Section cTxUnmS1 }
 type cTxUnmS1 struct{ Name unmarshalable }
 
+
+type anySection struct {
+	ExtraValues map[string]string
+}
+
+type cSubsectionAnyConfig struct {
+	Section map[string]*anySection
+}
+
+type cSectionAnyConfig struct {
+	Section anySection
+}
+
 type cNum struct {
 	N1 cNumS1
 	N2 cNumS2
@@ -268,6 +281,8 @@ var readtests = []struct {
 }}, {"type:textUnmarshaler", []readtest{
 	{"[section]\nname=value", &cTxUnm{Section: cTxUnmS1{Name: "value"}}, true},
 	{"[section]\nname=error", &cTxUnm{}, false},
+	{"[section]\nTest=test", &cSectionAnyConfig{anySection{ExtraValues: map[string]string{"Test": "test"}}}, true},
+	{"[section \"A\"]\nTest=test", &cSubsectionAnyConfig{map[string]*anySection{"A": {ExtraValues: map[string]string{"Test": "test"}}}}, true},
 }},
 }
 

--- a/read_test.go
+++ b/read_test.go
@@ -82,7 +82,6 @@ type cBoolS1 struct{ Bool bool }
 type cTxUnm struct{ Section cTxUnmS1 }
 type cTxUnmS1 struct{ Name unmarshalable }
 
-
 type anySection struct {
 	ExtraValues map[string]string
 }

--- a/set.go
+++ b/set.go
@@ -284,9 +284,8 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	if !vVar.IsValid() {
 		if err := setExtraDataInSection(vSect, name, value, l); err != nil {
 			return c.Collect(err)
-		} else {
-			return nil
 		}
+		return nil
 	}
 	// vVal is either single-valued var, or newly allocated value within multi-valued var
 	var vVal reflect.Value

--- a/set.go
+++ b/set.go
@@ -346,12 +346,11 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 }
 
 func setExtraDataInSection(vSect reflect.Value, key, value string, loc loc) *extraData {
-	if extraDataField := findExtraDataField(vSect); extraDataField == nil {
-		return &extraData{loc: loc}
-	} else {
+	if extraDataField := findExtraDataField(vSect); extraDataField != nil {
 		extraDataField.SetMapIndex(reflect.ValueOf(key), reflect.ValueOf(value))
 		return nil
 	}
+	return &extraData{loc: loc}
 }
 
 func findExtraDataField(vSect reflect.Value) *reflect.Value {


### PR DESCRIPTION
Allows us to set arbitrary config in sections. Will be useful to set:

```
[plugin "go"]
GoTool = go
```